### PR TITLE
refactor: make Record get initialized only once for the same object

### DIFF
--- a/src/app/app.mobile.jsx
+++ b/src/app/app.mobile.jsx
@@ -38,10 +38,10 @@ const render = (Component) => {
 render(RouterContainer);
 
 if (module.hot) {
-  console.log(123, 11);
-  module.hot.accept('./containers/RouterContainer/RouterContainer.mobile', () => {
-    const newRoutes = require('./containers/RouterContainer/RouterContainer.mobile').default;
-    console.log('hot replace');
+  const url = '@containers/RouterContainer/RouterContainer.mobile';
+  module.hot.accept(url, () => {
+    const newRoutes = require('@containers/RouterContainer/RouterContainer.mobile').default;
+    console.log('hot replace: %s', '@containers/RouterContainer/RouterContainer.mobile');
     render(newRoutes);
   });
 }

--- a/src/app/components/app/DefinitionList/DefinitionList.mobile.jsx
+++ b/src/app/components/app/DefinitionList/DefinitionList.mobile.jsx
@@ -24,14 +24,14 @@ const Definition = ({
     <StyledDefinition>
       <Row>
         <div>
-          {definition['term_label']}
+          {definition.get('term_label')}
         </div>
         <div>
-          {definition['pos']}
+          {definition.get('pos')}
         </div>
       </Row>
       <Row>
-        {definition['definition_label']}
+        {definition.get('definition_label')}
       </Row>
     </StyledDefinition>
   )

--- a/src/app/models/data/Definition.js
+++ b/src/app/models/data/Definition.js
@@ -14,20 +14,16 @@ export default class Definition extends Record({
   }
   
   static ofMany(data) {
-    if (data && data.map) {
-      return data.map((d) => {
-        return new Definition({
-          created_at: d.created_at,
-          definition_id: d.definition_id,
-          definition_label: d.definition_label,
-          pos: d.pos,
-          term_id: d.term_id,
-          term_label: d.term_label,
-          updated_at: d.updated_at,
-        });
+    return data && data.map && data.map((d) => {
+      return new Definition({
+        created_at: d.created_at,
+        definition_id: d.definition_id,
+        definition_label: d.definition_label,
+        pos: d.pos,
+        term_id: d.term_id,
+        term_label: d.term_label,
+        updated_at: d.updated_at,
       });
-    } else {
-      throw Error('definition error'); 
-    }
+    });
   }
 };

--- a/src/app/state/actions/definitionActions.js
+++ b/src/app/state/actions/definitionActions.js
@@ -6,21 +6,6 @@ import Logger from '@modules/Logger';
 
 const logger = new Logger('action');
 
-// const dummyDef = {
-//   created_at: 20,
-//   downvote: 10,
-//   id: 1,
-//   label: '기모찌',
-//   origins: ['power', '111origin'],
-//   poss: ['동사'],
-//   term_id: 2,
-//   updated_at: Date.now(),
-//   upvote: 2,
-//   usages: ['blabla', 'bleble'],
-//   user_id: 3,
-//   username: 'username123123',
-// };
-
 export function requestGetDefinitions({
   componentId,
   page,


### PR DESCRIPTION
Suppose we have `class A extends Record(...)`, and there could be multiple
constructions of A using new() operator. Only the first time when A is
constructed, will the prototype Record would get initialized.

Fixes https://github.com/marmoym/marmoym/issues/38

<!--- 
Thanks for the contribution. We appreciate it.
Be sure to checkout our guideline.
-->
## Related Issues

## Checklist
- [ ] Tested successfully.
- [ ] Titles of commit message and PR are in English.
- [ ] PR number at the title will be removed when `squash and merge`.
- [ ] [Guideline](https://github.com/tymsai/marmoym-dev-support/blob/dev/CONTRIBUTING.md#commit-messages) is followed. 