### PR TITLE
fix: make prod server load RootContainer correctly

### DIFF
--- a/internals/webpack/webpack.config.client.prod.web.js
+++ b/internals/webpack/webpack.config.client.prod.web.js
@@ -1,10 +1,28 @@
 const path = require('path');
 const webpack = require('webpack');
 
+const paths = require('../../src/server/paths');
 const webpackConfigClientWeb  = require('./webpack.config.client.web');
 
 const config = {
+  entry: {
+    app: path.resolve(paths.srcClient, 'client.tsx'),
+    react: [ 'react', 'react-dom', 'redux', 'react-redux' ],
+  },
   mode: 'production',
+  optimization: {
+    minimize: true,
+    runtimeChunk: false,
+    splitChunks: {
+      chunks: 'all',
+    }
+  },
+  output: {
+    path: paths.distPublicBundle,
+    filename: '[name].[chunkhash].js',
+    chunkFilename: 'chunk.[chunkhash].js',
+    publicPath: '/bundle/',
+  },
 };
 
 module.exports = Object.assign({}, webpackConfigClientWeb, config);

--- a/internals/webpack/webpack.config.client.web.js
+++ b/internals/webpack/webpack.config.client.web.js
@@ -5,10 +5,6 @@ const paths = require('../../src/server/paths');
 
 module.exports = {
   context: __dirname,
-  entry: {
-    app: path.resolve(paths.srcClient, 'client.tsx'),
-    react: [ 'react', 'react-dom', 'redux', 'react-redux' ],
-  },
   externals: {},
   module: {
     rules: [
@@ -46,22 +42,7 @@ module.exports = {
       },
     ],
   },
-  mode: 'production',
-  optimization: {
-    minimize: true,
-    runtimeChunk: false,
-    splitChunks: {
-      chunks: 'all',
-    }
-  },
-  output: {
-    path: paths.distPublicBundle,
-    filename: '[name].[chunkhash].js',
-    chunkFilename: 'chunk.[chunkhash].js',
-    publicPath: '/',
-  },
-  plugins: [
-  ],
+  plugins: [],
   resolve: {
     modules: [
       'node_modules',

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "version": "0.0.2",
   "description": "",
   "scripts": {
+    "build:prod": "./node_modules/.bin/gulp --gulpfile ./internals/gulp/gulpfile.js build:prod",
     "build:server": "./node_modules/.bin/gulp --gulpfile ./internals/gulp/gulpfile.js build:server",
     "dev:local": "NODE_ENV=development yarn run build:server && NODE_ENV=development node ./dist/babel/server/server.js",
-    "start:local": "cross-env NODE_ENV=development node ./src/server/server.js",
-    "start:prod": "cross-env NODE_ENV=production node ./src/server/server.js",
+    "start:local": "cross-env NODE_ENV=development node ./dist/babel/server/server.js",
+    "start:prod": "cross-env NODE_ENV=production node ./dist/babel/server/server.js",
     "pm2:start:prod": "pm2 startOrRestart ./internals/pm2/ecosystem.config.js --env production",
     "pm2:deploy": "pm2 deploy ./internals/pm2/ecosystem.config.js production",
     "test": "",

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -73,11 +73,11 @@ function launchLocalServer() {
 }
 
 function launchProdServer() {
-  const server = require('@server/serverApp/server.prod').default;
-  server.update({
-    rootContainerPath: '@containers/app/RootContainer/RootContainer.mobile',
-  });
-  runHttpServer(server.app);
+  const { app, state } = require('@server/serverApp/server.prod').default;
+  // state.update({
+  //   rootContainerPath: '@containers/app/RootContainer/RootContainer.mobile',
+  // });
+  runHttpServer(app);
 }
 
 function runHttpServer(app) {

--- a/src/server/serverApp/ServerApp.web.tsx
+++ b/src/server/serverApp/ServerApp.web.tsx
@@ -4,19 +4,21 @@ import { renderToString } from "react-dom/server";
 import { StaticRouter } from 'react-router-dom';
 import { Store } from 'redux';
 
+import RootContainerFallback from '@containers/app/RootContainer/RootContainer.mobile';
 import Log from '@server/modules/Log';
-import { Container } from "winston";
 
 const ServerApp: React.SFC<ServerAppProps> = ({
   requestUrl,
-  rootContainerPath = '',
+  rootContainerPath,
   store,
 }) => {
-  Log.info('<ServerApp/> with rootContainerPath: %s, with localServer: %s', rootContainerPath);
+  Log.info('<ServerApp/> with rootContainerPath: %s', rootContainerPath);
 
   let RootContainerComponent;
   try {
-    RootContainerComponent = require(rootContainerPath).default;
+    RootContainerComponent = rootContainerPath 
+      ? require(rootContainerPath).default
+      : RootContainerFallback;
   } catch (err) {
     Log.error('<App/> cannot find rootContainer at: %s', rootContainerPath, err);
     return <div>RootContainer not found</div>;

--- a/src/server/serverApp/createExpress.ts
+++ b/src/server/serverApp/createExpress.ts
@@ -37,8 +37,6 @@ export default function createServer({
     if (state.launchStatus !== LaunchStatus.LAUNCH_SUCCESS) {
       res.writeHead(500);
       res.end(util.format('server is not successfully launched, launch_status: %s', state.launchStatus));
-    } else if (state.rootContainerPath === undefined) {
-      res.end("RootContainer path is not defined yet. Are you running on local environment?");
     } else {
       res.writeHead(200, { "Content-Type": "text/html" });
       const html = makeHtml({

--- a/src/universal/apis/LpApis/apiMap.js
+++ b/src/universal/apis/LpApis/apiMap.js
@@ -1,6 +1,4 @@
-
 const ROOT = process.env.NODE_ENV === 'development' 
-  // ? `http://${window.location.hostname}:4001/api/v1`
   ? `http://localhost:4001/api/v1`
   : `http://api.marmoym.com/api/v1`;
 

--- a/src/universal/modules/Axios.js
+++ b/src/universal/modules/Axios.js
@@ -6,16 +6,10 @@ import Logger from '@modules/Logger';
 
 const logger = new Logger('axios');
 
-/**
- * ...
- */
 const axiosInstance = (function configureAxios() {
   const axiosInstance = axios.create();
   axiosInstance.defaults.timeout = 7000;
 
-  /**
-   * Logging
-   */
   DEV_ENV && axiosInstance.interceptors.request.use(req => {
     try {
       logger.axios(req.method, req.url, req.data);
@@ -38,5 +32,3 @@ export function selectAxiosPayload(res) {
 export function selectAxiosError(err) {
   return err.response ? err.response.data : err.response;
 };
-
-// export const NETWORK = '__network';


### PR DESCRIPTION
- `publicPath` of webpack config is modifed to serve `bundle/`.
- Starting script is slightly modified. `build:prod` is created.

Fixes https://github.com/marmoym/marmoym/issues/115

<!--- 
We appreciate your contribution. Be sure to check our guideline beforehand.
https://github.com/tymsai/marmoym-dev-support/blob/dev/CONTRIBUTING.md#commit-messages

- Including the issue URL in the commit message will be of great help
- Commit message is advised to have semantic tagging, e.g. `refactor: [title]`
- No merge commit. Use `squash` when merging with the Title not having `PR-NUMBER`
-->
